### PR TITLE
Disable Java 8 'doclint' checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -830,5 +830,22 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This allows building out-of-the-box with a Java 8 SDK.
